### PR TITLE
Adding vSphere Cloud Provider Support for Instances and Zones

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/net/context"
 	"gopkg.in/gcfg.v1"
 
+	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/api"
 )
@@ -148,7 +149,15 @@ func (vs *VSphere) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
 
 // Zones returns an implementation of Zones for Google vSphere.
 func (vs *VSphere) Zones() (cloudprovider.Zones, bool) {
-	return nil, true
+	glog.V(1).Info("Claiming to support Zones")
+
+	return vs, true
+}
+
+func (vs *VSphere) GetZone() (cloudprovider.Zone, error) {
+	glog.V(1).Infof("Current zone is %v", vs.cfg.Global.Datacenter)
+
+	return cloudprovider.Zone{Region: vs.cfg.Global.Datacenter}, nil
 }
 
 // Routes returns an implementation of Routes for vSphere.

--- a/pkg/cloudprovider/providers/vsphere/vsphere_test.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_test.go
@@ -117,3 +117,28 @@ func TestVSphereLogin(t *testing.T) {
 	}
 	defer c.Logout(ctx)
 }
+
+func TestZones(t *testing.T) {
+	cfg := VSphereConfig{}
+	cfg.Global.Datacenter = "myDatacenter"
+
+	// Create vSphere configuration object
+	vs, err := newVSphere(cfg)
+	if err != nil {
+		t.Fatalf("Failed to construct/authenticate vSphere: %s", err)
+	}
+
+	z, ok := vs.Zones()
+	if !ok {
+		t.Fatalf("Zones() returned false")
+	}
+
+	zone, err := z.GetZone()
+	if err != nil {
+		t.Fatalf("GetZone() returned error: %s", err)
+	}
+
+	if zone.Region != vs.cfg.Global.Datacenter {
+		t.Fatalf("GetZone() returned wrong region (%s)", zone.Region)
+	}
+}


### PR DESCRIPTION
vSphere login is moved out of vSphere object initialization into it's own method.  This allows for separate login to vSphere per request flow.  This pull request includes Instances skeleton and implementation for Zones.
#23932
