### PR TITLE
Retreive VM Name from Running Instance

### DIFF
--- a/pkg/cloudprovider/providers/providers.go
+++ b/pkg/cloudprovider/providers/providers.go
@@ -24,4 +24,5 @@ import (
 	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/openstack"
 	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/ovirt"
 	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/rackspace"
+	_ "k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere"
 )


### PR DESCRIPTION
When vSphere cloud provider object is instantiated, the VM name of the
Node where this object is being create in needs to be set.  This patch
also includes vSphere as part of the cloud provider package.
