### PR TITLE
Don't rely on device name provided by Cinder

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -683,26 +683,6 @@ func (os *OpenStack) DeleteVolume(volumeName string) error {
 	return err
 }
 
-// Get device path of attached volume to the compute running kubelet
-func (os *OpenStack) GetAttachmentDiskPath(instanceID string, diskName string) (string, error) {
-	disk, err := os.getVolume(diskName)
-	if err != nil {
-		return "", err
-	}
-	if len(disk.Attachments) > 0 && disk.Attachments[0]["server_id"] != nil {
-		if instanceID == disk.Attachments[0]["server_id"] {
-			// Attachment[0]["device"] points to the device path
-			// see http://developer.openstack.org/api-ref-blockstorage-v1.html
-			return disk.Attachments[0]["device"].(string), nil
-		} else {
-			errMsg := fmt.Sprintf("Disk %q is attached to a different compute: %q, should be detached before proceeding", diskName, disk.Attachments[0]["server_id"])
-			glog.Errorf(errMsg)
-			return "", errors.New(errMsg)
-		}
-	}
-	return "", fmt.Errorf("volume %s is not attached to %s", diskName, instanceID)
-}
-
 // query if a volume is attached to a compute instance
 func (os *OpenStack) DiskIsAttached(diskName, instanceID string) (bool, error) {
 	disk, err := os.getVolume(diskName)

--- a/pkg/cloudprovider/providers/rackspace/rackspace.go
+++ b/pkg/cloudprovider/providers/rackspace/rackspace.go
@@ -613,26 +613,6 @@ func (rs *Rackspace) DetachDisk(instanceID string, partialDiskId string) error {
 	return nil
 }
 
-// Get device path of attached volume to the compute running kubelet
-func (rs *Rackspace) GetAttachmentDiskPath(instanceID string, diskName string) (string, error) {
-	disk, err := rs.getVolume(diskName)
-	if err != nil {
-		return "", err
-	}
-	if len(disk.Attachments) > 0 && disk.Attachments[0]["server_id"] != nil {
-		if instanceID == disk.Attachments[0]["server_id"] {
-			// Attachment[0]["device"] points to the device path
-			// see http://developer.openstack.org/api-ref-blockstorage-v1.html
-			return disk.Attachments[0]["device"].(string), nil
-		} else {
-			errMsg := fmt.Sprintf("Disk %q is attached to a different compute: %q, should be detached before proceeding", diskName, disk.Attachments[0]["server_id"])
-			glog.Errorf(errMsg)
-			return "", errors.New(errMsg)
-		}
-	}
-	return "", fmt.Errorf("volume %s is not attached to %s", diskName, instanceID)
-}
-
 // query if a volume is attached to a compute instance
 func (rs *Rackspace) DiskIsAttached(diskName, instanceID string) (bool, error) {
 	disk, err := rs.getVolume(diskName)

--- a/pkg/volume/cinder/cinder.go
+++ b/pkg/volume/cinder/cinder.go
@@ -48,7 +48,6 @@ type CinderProvider interface {
 	CreateVolume(name string, size int, tags *map[string]string) (volumeName string, err error)
 	GetDevicePath(diskId string) string
 	InstanceID() (string, error)
-	GetAttachmentDiskPath(instanceID string, diskName string) (string, error)
 	DiskIsAttached(diskName, instanceID string) (bool, error)
 	Instances() (cloudprovider.Instances, bool)
 }


### PR DESCRIPTION
See issue #33128

We can't rely on the device name provided by Cinder, and thus must perform
detection based on the drive serial number (aka It's cinder ID) on the
kubelet itself.

This patch re-works the cinder volume attacher (the parts executed in
kube-controller-manager) to return the volume ID, rather than the device
name as advertised by Cinder. We then rework the cinder volume attacher
(this time, the parts executed in kubelet) to accept this ID, and call the
pre-existing GetDevicePath method, will will perform the discovery
correctly.

This is a break in the Attacher interface, which explicitly calls for the
Attach method to return a device name.
