### PR TITLE
CAPS-1089 Remove node from kubernetes when deleted

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -433,6 +433,9 @@ func (i *Instances) NodeAddresses(name string) ([]api.NodeAddress, error) {
 func (i *Instances) ExternalID(name string) (string, error) {
 	srv, err := getServerByName(i.compute, name)
 	if err != nil {
+		if err == ErrNotFound {
+			return "", cloudprovider.InstanceNotFound
+		}
 		return "", err
 	}
 	return srv.ID, nil


### PR DESCRIPTION
The openstack cloudprovider had a bug in ExternalID, where it
returns the wrong error  when the specified node is not found,
so the node controller does not evict the node from kubernetes
when it has been deleted.
